### PR TITLE
handle queue not found error in queue inspector

### DIFF
--- a/inspector.go
+++ b/inspector.go
@@ -142,6 +142,9 @@ func (i *Inspector) GetQueueInfo(queue string) (*QueueInfo, error) {
 		return nil, err
 	}
 	stats, err := i.rdb.CurrentStats(queue)
+	if errors.IsQueueNotFound(err) {
+		return nil, fmt.Errorf("%w: queue=%q", ErrQueueNotFound, queue)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/inspector_test.go
+++ b/inspector_test.go
@@ -421,6 +421,18 @@ func TestInspectorGetQueueInfo(t *testing.T) {
 
 }
 
+func TestInspectorGetQueueInfoNotFound(t *testing.T) {
+	r := setup(t)
+	defer r.Close()
+
+	inspector := NewInspector(getRedisConnOpt(t))
+	h.FlushDB(t, r)
+	_, err := inspector.GetQueueInfo("nonexistent")
+	if !errors.Is(err, ErrQueueNotFound) {
+		t.Errorf("GetQueueInfo returned unexpected error: %v, want ErrQueueNotFound", err)
+	}
+}
+
 func TestInspectorHistory(t *testing.T) {
 	r := setup(t)
 	defer r.Close()


### PR DESCRIPTION
inspector.DeleteQueue has error handling for queue not found but inspector.GetQueueInfo was missing this logic